### PR TITLE
removing .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.csv filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Removing the LFS .gitattributes file since we dont see to have large files, and no one else has it enabled. Should reduce merge errors.